### PR TITLE
ci: migrate runners from lux-build to hanzo-build (ARC consolidation)

### DIFF
--- a/.github/workflows/build-linux-binaries.yml
+++ b/.github/workflows/build-linux-binaries.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build-x86_64-binaries-tarball:
-    runs-on: lux-build-linux-amd64
+    runs-on: hanzo-build-linux-amd64
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/build-ubuntu-amd64-release.yml
+++ b/.github/workflows/build-ubuntu-amd64-release.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build-jammy-amd64-package:
-    runs-on: lux-build-linux-amd64
+    runs-on: hanzo-build-linux-amd64
     permissions:
       id-token: write
       contents: read
@@ -66,7 +66,7 @@ jobs:
           rm -rf /tmp/luxd
 
   build-focal-amd64-package:
-    runs-on: lux-build-linux-amd64
+    runs-on: hanzo-build-linux-amd64
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,8 +15,8 @@ jobs:
     uses: hanzoai/.github/.github/workflows/docker-build.yml@main
     with:
       image: ghcr.io/luxfi/node
-      runner-amd64: lux-build-linux-amd64
-      runner-arm64: lux-build-arm64
+      runner-amd64: hanzo-build-linux-amd64
+      runner-arm64: hanzo-build-linux-arm64
     secrets: inherit
 
   notify-universe:


### PR DESCRIPTION
## Summary
- Migrate 3 workflows to hanzo ARC:
  - `docker.yml`: runner-amd64/arm64 → hanzo-build-linux-amd64/arm64
  - `build-ubuntu-amd64-release.yml`: both jammy + focal jobs → hanzo-build-linux-amd64
  - `build-linux-binaries.yml`: x86_64 tarball job → hanzo-build-linux-amd64
- Part of ARC fleet consolidation: one canonical self-hosted runner pool for hanzo/lux/zoo/liquidity.

## Why
Duplicate scale sets (lux-build-* and hanzo-build-*) violate "one way to do everything". The hanzo ARC is the canonical fleet per hanzo/CLAUDE.md:
- hanzo-build-linux-amd64 (DO ARC, max 30) — x86 builds
- hanzo-build-linux-arm64 (GKE T2A Ampere ARC, max 30) — ARM builds
- hanzo-deploy-linux-amd64 (DO ARC, max 20) — kubectl deploys

Note: `build-linux-binaries.yml` wasn't in the initial migration spec but has a matching `lux-build-linux-amd64` reference — included here so the repo is fully clean in one PR.

After this and the matching lux/universe PR lands, the lux-build-linux-amd64 scale set spins down to 0 replicas.

## Test plan
- [ ] Push schedules docker workflow on hanzo-build-linux-amd64/arm64
- [ ] Multi-arch image publishes to ghcr.io/luxfi/node
- [ ] Tag push builds both jammy + focal debian packages
- [ ] Tag push builds x86_64 release tarball