### PR TITLE
canonical evmAddr/utxoAddr — bump genesis v1.12.15 (no back-compat shim)

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -140,8 +140,8 @@ else
 {
   "allocations": [
     {
-      "luxAddr": "P-local1jfdgmqduuyuxjp9sq7szp08xpynav88sd7qxvv",
-      "ethAddr": "0x9011E888251AB053B7bD1cdB598Db4f9DEd94714",
+      "utxoAddr": "P-local1jfdgmqduuyuxjp9sq7szp08xpynav88sd7qxvv",
+      "evmAddr": "0x9011E888251AB053B7bD1cdB598Db4f9DEd94714",
       "initialAmount": 1000000000000000000,
       "unlockSchedule": []
     }
@@ -167,8 +167,8 @@ EOF
 {
   "allocations": [
     {
-      "luxAddr": "X-local1jfdgmqduuyuxjp9sq7szp08xpynav88sd7qxvv",
-      "ethAddr": "0x9011E888251AB053B7bD1cdB598Db4f9DEd94714",
+      "utxoAddr": "X-local1jfdgmqduuyuxjp9sq7szp08xpynav88sd7qxvv",
+      "evmAddr": "0x9011E888251AB053B7bD1cdB598Db4f9DEd94714",
       "initialAmount": 1000000000000000000,
       "unlockSchedule": []
     }

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 	github.com/luxfi/constants v1.5.7
 	github.com/luxfi/container v0.0.4
 	github.com/luxfi/filesystem v0.0.1
-	github.com/luxfi/genesis v1.12.14
+	github.com/luxfi/genesis v1.12.15
 	github.com/luxfi/geth v1.16.98
 	github.com/luxfi/go-bip39 v1.1.2
 	github.com/luxfi/lattice/v7 v7.1.0

--- a/go.sum
+++ b/go.sum
@@ -286,8 +286,8 @@ github.com/luxfi/filesystem v0.0.1 h1:VZ6xMFKaAPBW/ddlMsDnI2G0VU1lV5rYaVcW5d+KwE
 github.com/luxfi/filesystem v0.0.1/go.mod h1:OQVSU6XNwqrr1AI+MqkID2taHUclx7NYmmr3svgttec=
 github.com/luxfi/formatting v1.0.1 h1:ZnE1rAdEUds9yAegdVdGDOBGN6hLMPOv6E03Fp8IEYo=
 github.com/luxfi/formatting v1.0.1/go.mod h1:mYzNf5DJOiqSSKUPzNj5dKy4tstFbN3pZlkI5716eKc=
-github.com/luxfi/genesis v1.12.14 h1:/31ZAymyH+Zj/QCXI6To2agYLYF5pucBm5L2DIuGK+o=
-github.com/luxfi/genesis v1.12.14/go.mod h1:QHBJQrOarpM1q+xgo7wL119CuLSsTjrFwYJLv5x9pwQ=
+github.com/luxfi/genesis v1.12.15 h1:Q1I7ZsvJ2DdaQTo8939whSjS7LaEjVaKLcpfbJQZy80=
+github.com/luxfi/genesis v1.12.15/go.mod h1:D0uksf3ID3Syb4FU7EE77OU+yaU5zHSsUoUS5Ev8D/E=
 github.com/luxfi/geth v1.16.98 h1:w187TtKuGStf3tm2bshuHVKBv2Frjx0lT54kQVXyNHA=
 github.com/luxfi/geth v1.16.98/go.mod h1:6kEzSExdk9CPQDPXALt6P3HfQqBq7KF1Jrrv9gBpxbU=
 github.com/luxfi/go-bip32 v1.0.2 h1:7vFbb+Wr4Z499q2tuCLdd7wWjtn8sH+HWBlx76mhH9Y=


### PR DESCRIPTION
## Summary
- Bump luxfi/genesis v1.12.14 → v1.12.15 (strips legacy luxAddr/ethAddr alias shim).
- docker-entrypoint.sh genesis templates: luxAddr → utxoAddr, ethAddr → evmAddr.
- AllocationJSON now emits and accepts ONLY canonical evmAddr/utxoAddr.

Per "no backwards compatibility only forwards perfection". Coordinates with v1.23.43 tag (devnet bump path) — testnet/mainnet remain on v1.23.31 until coordinated migration.

## Test plan
- [x] go build ./... — clean
- [x] go test ./genesis/... ./vms/platformvm/genesis/... — green
- [x] End-to-end parse of configs/devnet/genesis.json — 1005 allocations, 5 stakers, evmAddr/utxoAddr both populated
- [ ] CI builds ghcr.io/luxfi/node:v1.23.43
- [ ] lux-devnet pods Ready after image bump
- [ ] L2 EVMs (hanzo/zoo/pars/spc) still serve chain reads