### PR TITLE
docs: align Go version in README and CONTRIBUTING with go.mod (1.26.3)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to Lux Node! This document provides 
 
 To start developing on Lux Node, you'll need a few things installed.
 
-- Golang version >= 1.23.9
+- Golang version >= 1.26.3
 - gcc
 - g++
 
@@ -34,7 +34,7 @@ We are committed to fostering a welcoming and inclusive community. Please be res
 
 ### Prerequisites
 
-- Go 1.21.12 or higher
+- Go 1.26.3 or higher
 - Git
 - Make
 - GCC/G++ compiler

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ---
 
 [![Build Status](https://github.com/luxfi/node/actions/workflows/ci.yml/badge.svg)](https://github.com/luxfi/node/actions)
-[![Go Version](https://img.shields.io/badge/go-1.21.12-blue.svg)](https://golang.org/)
+[![Go Version](https://img.shields.io/badge/go-1.26.3-blue.svg)](https://golang.org/)
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](LICENSE)
 
 Node implementation for the [Lux](https://lux.network) network -
@@ -38,7 +38,7 @@ The minimum recommended hardware specification for nodes connected to Mainnet is
 
 If you plan to build Lux Node from source, you will also need the following software:
 
-- [Go](https://golang.org/doc/install) version >= 1.23.9
+- [Go](https://golang.org/doc/install) version >= 1.26.3
 - [gcc](https://gcc.gnu.org/)
 - g++
 


### PR DESCRIPTION
### Why

The docs disagree with each other and with `go.mod` about the minimum Go toolchain. A new contributor who follows the README badge installs Go 1.21.12, hits the prerequisites line that says 1.23.9, and then `go build` fails because `go.mod` declares `go 1.26.3`. Fixing this saves the first-build friction.

### What changed

- `README.md` badge: `1.21.12` to `1.26.3`
- `README.md` "Building From Source" prerequisite: `>= 1.23.9` to `>= 1.26.3`
- `CONTRIBUTING.md` top-of-file prerequisite: `>= 1.23.9` to `>= 1.26.3`
- `CONTRIBUTING.md` "Prerequisites" section: `1.21.12 or higher` to `1.26.3 or higher`

Source of truth: `go.mod` line 10 (`go 1.26.3`). `Dockerfile` ARG is `1.26.1` which already builds against the same toolchain line.

### What didn't change

- No code, no `go.mod` / `go.sum`, no workflows, no lockfiles.
- Other Go-version mentions inside `HISTORY.md` / `RELEASES.md` are left alone since they describe historical releases.